### PR TITLE
[RFC] Add decay system for openskill

### DIFF
--- a/src/lib/mathUtils.ts
+++ b/src/lib/mathUtils.ts
@@ -1,0 +1,26 @@
+/**
+ * Normalize a number in a range
+ *
+ * @example norm(10, 0, 100); // 0.1
+ *
+ * @param value value to be normalized
+ * @param start start of range
+ * @param end end of range
+ * @returns
+ */
+export const normalize = (value: number, start: number, end: number) => {
+  return (value - start) / (end - start);
+};
+
+/**
+ * Maps a normalized number into a number range
+ *
+ * @example lerp(0.1, 0, 100); // 10
+ *
+ * @param value value to be mapped, must be between 0 and 1
+ * @param start start of range
+ * @param end end of range
+ */
+export const lerp = (value: number, start: number, end: number) => {
+  return start + value * (end - start);
+};


### PR DESCRIPTION
Add decay of rating for openskill with the following logic before _using_ a rating:

- The player receives NO penalty if they HAVE played a match in the last 21 days.
- The penalty the player receives is scaled to how long they have been inactive - between 3 weeks and 12 weeks - capped at 12 weeks.
- Mu (skill level) can decay to the midpoint between default mu (1000) and pre-decay mu at the lowest
- Mu cannot decay to a value higher than pre-decay mu
- Sigma (uncertainty) can decay to the quarter-point between pre-decay sigma and default sigma (500) at the highest
- Sigma cannot decay to a value lower than pre-decay sigma

Not sure how good that explanation is ⬆️, but I can't think of a better way to explain it.
HMU @ the office if you want me to try and explain it to you.

Also the decay factors for mu and sigma are just a guess for something that could work, so maybe they need some work 🤷

I'm not sure if I like the complexity it adds (with this implementation). Fx the fact that it has to be called in 3 separate locations.