### PR TITLE
Feature: See previous seasons

### DIFF
--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -1,0 +1,16 @@
+interface SelectGetProps {
+  id: string;
+  config: unknown;
+}
+
+export const Chart = ({ id, config }: SelectGetProps) => (
+  <>
+    <canvas id={id} />
+    {/* Inserting a <script> tag with innerHtml (used by HTMX in hx-get) does not execute the code, but using onload on a <style> tag will */}
+    <style
+      onload={`new Chart(document.getElementById("${id}"), ${JSON.stringify(
+        config,
+      )})`}
+    ></style>
+  </>
+);

--- a/src/components/LeaderboardRow.tsx
+++ b/src/components/LeaderboardRow.tsx
@@ -9,6 +9,7 @@ export const LeaderboardRowHtml = async ({
   rating,
   lastPlayed,
   latestPlayerResults,
+  isCurrentSeason,
 }: {
   userId: string;
   rank: number;
@@ -20,6 +21,7 @@ export const LeaderboardRowHtml = async ({
     loseStreak: number;
     results: RESULT[];
   } | null;
+  isCurrentSeason: boolean;
 }) => {
   const { loseStreak, results, winStreak } = latestPlayerResults || {};
 
@@ -38,6 +40,7 @@ export const LeaderboardRowHtml = async ({
             lastPlayed={lastPlayed}
             streak={streak}
             isWinStreak={isWinStreak}
+            isCurrentSeason={isCurrentSeason}
           />
         </div>
         <img
@@ -65,12 +68,14 @@ export const WinLoseStreak = ({
   streak,
   isWinStreak,
   lastPlayed,
+  isCurrentSeason,
 }: {
   lastPlayed: Date | undefined;
   streak: number | undefined;
   isWinStreak: boolean;
+  isCurrentSeason: boolean;
 }) => {
-  if (lastPlayed && isDateOlderThanNDays(lastPlayed, 7)) {
+  if (isCurrentSeason && lastPlayed && isDateOlderThanNDays(lastPlayed, 7)) {
     return <span class="pr-2 text-2xl">💤</span>;
   }
   if (streak && streak === 5) {

--- a/src/components/LeaderboardRow.tsx
+++ b/src/components/LeaderboardRow.tsx
@@ -7,8 +7,6 @@ export const LeaderboardRowHtml = async ({
   rank,
   name,
   rating,
-  first,
-  page,
   lastPlayed,
   latestPlayerResults,
 }: {
@@ -16,8 +14,6 @@ export const LeaderboardRowHtml = async ({
   rank: number;
   name: string;
   rating: number;
-  first: boolean;
-  page: number;
   lastPlayed: Date;
   latestPlayerResults: {
     winStreak: number;
@@ -28,84 +24,40 @@ export const LeaderboardRowHtml = async ({
   const { loseStreak, results, winStreak } = latestPlayerResults || {};
 
   const streak = winStreak || loseStreak || undefined;
-  const isWinStreak = !!winStreak ?? !!loseStreak;
+  const isWinStreak = !!winStreak;
 
   return (
-    <>
-      {first ? (
-        <tr
-          class="border-b border-gray-700 bg-gray-800"
-          hx-get={`/leaderboard/page/${page + 1}`}
-          _="on htmx:afterRequest remove @hx-trigger from me"
-          hx-indicator=".progress-bar"
-          hx-trigger="intersect once"
-          hx-swap="beforeend"
-          hx-target={`#nextPageData`}
-        >
-          <td class="px-1 py-4 pl-2 md:px-3 lg:px-6">{rank}.</td>
-          <th
-            scope="row"
-            class="grid grid-cols-12 items-center gap-3 whitespace-nowrap px-1 py-4 font-medium text-white md:flex md:px-3 lg:px-6"
+    <tr class="border-b border-gray-700 bg-gray-800">
+      <td class="px-1 py-4 pl-2 md:px-3 lg:px-6">{rank}.</td>
+      <th
+        scope="row"
+        class="grid grid-cols-12 items-center gap-3 whitespace-nowrap px-1 py-4 font-medium text-white md:flex md:px-3 lg:px-6"
+      >
+        <div class="col-span-2">
+          <WinLoseStreak
+            lastPlayed={lastPlayed}
+            streak={streak}
+            isWinStreak={isWinStreak}
+          />
+        </div>
+        <img
+          class="col-span-2 mr-1 inline-block h-8 w-8 rounded-full ring-2 ring-gray-700 lg:mr-3 lg:h-8 lg:w-8"
+          src={`/static/user/${userId}/small`}
+          loading="lazy"
+          alt=""
+        />
+        <div class="col-span-8 flex flex-col gap-0 text-left">
+          <HxButton
+            class="w-44 overflow-hidden truncate whitespace-nowrap text-left md:w-full"
+            hx-get={`/profile/${userId}`}
           >
-            <div class="col-span-2">
-              <WinLoseStreak
-                lastPlayed={lastPlayed}
-                streak={streak}
-                isWinStreak={isWinStreak}
-              />
-            </div>
-            <img
-              class="col-span-2 mr-1 inline-block h-8 w-8 rounded-full ring-2 ring-gray-700 lg:mr-3 lg:h-8 lg:w-8"
-              src={`/static/user/${userId}/small`}
-              loading="lazy"
-              alt=""
-            />
-            <div class="col-span-8 flex flex-col gap-0 text-left">
-              <HxButton
-                class="w-44 overflow-hidden truncate whitespace-nowrap text-left"
-                hx-get={`/profile/${userId}`}
-              >
-                {name}
-              </HxButton>
-              <LatestResults latestPlayerResults={results} />
-            </div>
-          </th>
-          <td class="px-1 py-4 md:px-3 lg:px-6">{rating}</td>
-        </tr>
-      ) : (
-        <tr class="border-b border-gray-700 bg-gray-800">
-          <td class="px-1 py-4 pl-2 md:px-3 lg:px-6">{rank}.</td>
-          <th
-            scope="row"
-            class="grid grid-cols-12 items-center gap-3 whitespace-nowrap px-1 py-4 font-medium text-white md:flex md:px-3 lg:px-6"
-          >
-            <div class="col-span-2">
-              <WinLoseStreak
-                lastPlayed={lastPlayed}
-                streak={streak}
-                isWinStreak={isWinStreak}
-              />
-            </div>
-            <img
-              class="col-span-2 mr-1 inline-block h-8 w-8 rounded-full ring-2 ring-gray-700 lg:mr-3 lg:h-8 lg:w-8"
-              src={`/static/user/${userId}/small`}
-              loading="lazy"
-              alt=""
-            />
-            <div class="col-span-8 flex flex-col gap-0 text-left">
-              <HxButton
-                class="w-44 overflow-hidden truncate whitespace-nowrap text-left md:w-full"
-                hx-get={`/profile/${userId}`}
-              >
-                {name}
-              </HxButton>
-              <LatestResults latestPlayerResults={results} />
-            </div>
-          </th>
-          <td class="px-1 py-4 md:px-3 lg:px-6">{rating}</td>
-        </tr>
-      )}
-    </>
+            {name}
+          </HxButton>
+          <LatestResults latestPlayerResults={results} />
+        </div>
+      </th>
+      <td class="px-1 py-4 md:px-3 lg:px-6">{rating}</td>
+    </tr>
   );
 };
 

--- a/src/components/LeaderboardTable.tsx
+++ b/src/components/LeaderboardTable.tsx
@@ -3,6 +3,7 @@ import { LeaderboardRowHtml } from "./LeaderboardRow";
 
 export const LeaderboardTableHtml = ({
   rows,
+  isCurrentSeason,
 }: {
   rows: {
     userId: string;
@@ -16,6 +17,7 @@ export const LeaderboardTableHtml = ({
       results: RESULT[];
     } | null;
   }[];
+  isCurrentSeason: boolean;
 }) => (
   <>
     <div class="flex flex-col items-center justify-center">
@@ -36,7 +38,7 @@ export const LeaderboardTableHtml = ({
           </thead>
           <tbody id="nextPageData">
             {rows.map((row) => (
-              <LeaderboardRowHtml {...row} />
+              <LeaderboardRowHtml {...row} isCurrentSeason={isCurrentSeason} />
             ))}
           </tbody>
         </table>

--- a/src/components/LeaderboardTable.tsx
+++ b/src/components/LeaderboardTable.tsx
@@ -3,9 +3,7 @@ import { LeaderboardRowHtml } from "./LeaderboardRow";
 
 export const LeaderboardTableHtml = ({
   rows,
-  page,
 }: {
-  page: number;
   rows: {
     userId: string;
     rank: number;
@@ -37,8 +35,8 @@ export const LeaderboardTableHtml = ({
             </tr>
           </thead>
           <tbody id="nextPageData">
-            {rows.map((row, index) => (
-              <LeaderboardRowHtml {...row} first={index === 0} page={page} />
+            {rows.map((row) => (
+              <LeaderboardRowHtml {...row} />
             ))}
           </tbody>
         </table>

--- a/src/components/SelectGet.tsx
+++ b/src/components/SelectGet.tsx
@@ -1,0 +1,40 @@
+import { cn } from "../lib/utils";
+
+interface SelectGetProps {
+  options: { path: string; text: string }[];
+  selectedIndex?: number;
+  target?: string;
+  selectClass?: string;
+  optionClass?: string;
+}
+
+export const SelectGet = ({
+  options,
+  selectedIndex,
+  target,
+  selectClass,
+  optionClass,
+}: SelectGetProps) => (
+  <select
+    class={cn(
+      "block w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400 dark:focus:border-blue-500 dark:focus:ring-blue-500",
+      selectClass,
+    )}
+    _={`on change
+        set targetUrl to event.srcElement.value
+        fetch \`\${targetUrl}\`
+        then put it after ${target ?? "#mainContainer"}
+        then remove ${target ?? "#mainContainer"}
+        then call htmx.process(document.body)`}
+  >
+    {options.map((x, i) => (
+      <option
+        class={optionClass ?? ""}
+        value={x.path}
+        selected={i === selectedIndex}
+      >
+        {x.text}
+      </option>
+    ))}
+  </select>
+);

--- a/src/pages/(home).tsx
+++ b/src/pages/(home).tsx
@@ -1,9 +1,12 @@
 import { Elysia } from "elysia";
 import { ctx } from "../context";
+import { getActiveSeason } from "../db/queries/seasonQueries";
 import { LeaderboardPage } from "./leaderboard";
 
 export const home = new Elysia()
   .use(ctx)
   .get("/", async ({ headers, html, session }) => {
-    return html(() => LeaderboardPage(session, headers));
+    const activeSeason = await getActiveSeason();
+    const activeSeasonId = activeSeason?.id ?? 1;
+    return html(() => LeaderboardPage(session, headers, activeSeasonId));
   });

--- a/src/pages/leaderboard.tsx
+++ b/src/pages/leaderboard.tsx
@@ -106,15 +106,3 @@ async function LeaderboardTable(
     </>
   );
 }
-
-export async function PagedLeaderboard(seasonId: number) {
-  const rows = await playerQuery(seasonId);
-
-  return (
-    <>
-      {rows.map((row) => (
-        <LeaderboardRowHtml {...row} />
-      ))}
-    </>
-  );
-}

--- a/src/pages/leaderboard.tsx
+++ b/src/pages/leaderboard.tsx
@@ -13,6 +13,7 @@ import {
   getSeason,
   getSeasons,
 } from "../db/queries/seasonQueries";
+import { type Season } from "../db/schema/season";
 import { isHxRequest } from "../lib";
 import MatchStatistics, { type RESULT } from "../lib/matchStatistics";
 import { getRatings, getRatingSystem } from "../lib/rating";
@@ -102,7 +103,18 @@ async function LeaderboardTable(
           ></SelectGet>
         </div>
       </div>
-      <LeaderboardTableHtml rows={rows}></LeaderboardTableHtml>
+      <LeaderboardTableHtml
+        rows={rows}
+        isCurrentSeason={isCurrentSeason(seasonId, seasons)}
+      ></LeaderboardTableHtml>
     </>
   );
+}
+
+function isCurrentSeason(seasonId: number, seasons: Season[]): boolean {
+  const now = Date.now();
+  const { id: currentSeasonId } = seasons.find(
+    ({ startAt, endAt }) => now > startAt.getTime() && now < endAt.getTime(),
+  ) ?? { id: -1 };
+  return currentSeasonId == seasonId;
 }

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -1,6 +1,7 @@
 import { type ChartConfiguration } from "chart.js";
 import Elysia from "elysia";
 import { type Session } from "lucia";
+import { Chart } from "../components/Chart";
 import { HeaderHtml } from "../components/header";
 import { LayoutHtml } from "../components/Layout";
 import { MatchResultLink } from "../components/MatchResultLink";
@@ -235,16 +236,11 @@ const profileStats = (
       <StatsCardHtml title="Winrate">
         <>
           <div class="flex h-48 w-full items-center justify-center pt-5">
-            <canvas id="chartDoughnut"></canvas>
+            <Chart id="chartDoughnut" config={winrateConfig}></Chart>
             <span class="pl-3 text-sm">
               {winRate.winPercentage.toFixed(2)}%
             </span>
           </div>
-          <script>
-            {`new Chart(document.getElementById("chartDoughnut"), ${JSON.stringify(
-              winrateConfig,
-            )})`}
-          </script>
         </>
       </StatsCardHtml>
       <StatsCardHtml title="Winrate By Color">
@@ -297,13 +293,8 @@ const profileStats = (
       <StatsCardHtml title="Rating history">
         <>
           <div class="flex h-48 w-full items-center justify-center pt-5">
-            <canvas id="ratingChart"></canvas>
+            <Chart id="ratingChart" config={ratingTrendConfig}></Chart>
           </div>
-          <script>
-            {`new Chart(document.getElementById("ratingChart"), ${JSON.stringify(
-              ratingTrendConfig,
-            )})`}
-          </script>
         </>
       </StatsCardHtml>
       <StatsCardHtml title="Hardest opponents">

--- a/src/pages/stats.tsx
+++ b/src/pages/stats.tsx
@@ -1,6 +1,7 @@
 import { type ChartConfiguration } from "chart.js";
 import { Elysia } from "elysia";
 import { type Session } from "lucia";
+import { Chart } from "../components/Chart";
 import { HeaderHtml } from "../components/header";
 import { LayoutHtml } from "../components/Layout";
 import { MatchResultLink } from "../components/MatchResultLink";
@@ -155,16 +156,9 @@ async function page(session: Session | null, seasonId: number) {
         </StatsCardHtml>
         <StatsCardHtml title="Biggest win">{biggestWin(matches)}</StatsCardHtml>
         <StatsCardHtml title="Winrates">
-          <>
-            <div class="flex h-48 w-full items-center justify-center pt-5">
-              <canvas class="" id="chartDoughnut"></canvas>
-            </div>
-            <script>
-              {`new Chart(document.getElementById("chartDoughnut"), ${JSON.stringify(
-                config,
-              )})`}
-            </script>
-          </>
+          <div class="flex h-48 w-full items-center justify-center pt-5">
+            <Chart id="chartDoughnut" config={config}></Chart>
+          </div>
         </StatsCardHtml>
         <StatsCardHtml title="Winrate By Color">
           <>


### PR DESCRIPTION
Allows picking previous seasons on the leaderboard, profiles and stats-page.

Additionally:
* Introduces a <select> like component that supports a hx-get like behaviour implemented using hyperscript
* Removes the current pagination of the leaderboard.  