### PR TITLE
Inline js function in hyperscript

### DIFF
--- a/src/components/UserLookup.tsx
+++ b/src/components/UserLookup.tsx
@@ -10,17 +10,11 @@ interface Props extends JSX.HtmlInputTag {
 
 export const UserLookUp = ({ formId, input, label, user, ...props }: Props) => (
   <>
-    <script>
-      {function checkUserKeydown(event: Event) {
-        // Don't submit a search on enter or when selecting an entry with the mouse
-        return event instanceof KeyboardEvent && event.key !== "Enter";
-      }}
-    </script>
     <SearchIcon />
     <input
       id={`${input}-input`}
       form={formId}
-      hx-trigger="keyup[checkUserKeydown.call(this, event)] changed delay:300ms"
+      hx-trigger="keyup[event.key !== 'Enter'] changed delay:300ms"
       hx-sync="this:replace"
       hx-swap="innerHtml"
       hx-get="/match/search"


### PR DESCRIPTION
I found more javascript, so I inlined it in the hyperscript. 

I'm removing a check that the event is a KeyboardEvent, but it should always be one since it's triggered by "keyup"