### PR TITLE
New algo summer 2026 ????

### DIFF
--- a/src/components/LeaderboardRow.tsx
+++ b/src/components/LeaderboardRow.tsx
@@ -1,6 +1,7 @@
 import { getIsItChristmas } from "../controllers/holidays/christmas";
 import { isDateOlderThanNDays } from "../lib/dateUtils";
 import { RESULT } from "../lib/matchStatistics";
+import { type Rating, type RatingSystem } from "../lib/ratings/rating";
 import { cn, hashCode } from "../lib/utils";
 import { DiffIcon } from "./DiffIcon";
 import { HxButton } from "./HxButton";
@@ -12,6 +13,7 @@ export const LeaderboardRowHtml = ({
   name,
   rating,
   ratingBefore,
+  ratingSystem,
   rankBefore,
   lastPlayed,
   latestPlayerResults,
@@ -21,8 +23,9 @@ export const LeaderboardRowHtml = ({
   userId: string;
   rank: number;
   name: string;
-  rating: number;
-  ratingBefore?: number;
+  rating: Rating;
+  ratingBefore?: Rating;
+  ratingSystem: RatingSystem<Rating>;
   rankBefore?: number;
   lastPlayed: Date;
   latestPlayerResults: {
@@ -64,8 +67,16 @@ export const LeaderboardRowHtml = ({
         </div>
       </td>
       <td class="px-1 py-4 md:px-3 lg:px-6">
-        <span>{rating}</span>
-        <DiffIcon before={ratingBefore} after={rating} isHigherBetter={true} />
+        <span>{ratingSystem.toNumber(rating)}</span>
+        <DiffIcon
+          before={
+            ratingBefore !== undefined
+              ? ratingSystem.toNumber(ratingBefore)
+              : undefined
+          }
+          after={ratingSystem.toNumber(rating)}
+          isHigherBetter={true}
+        />
       </td>
     </tr>
   );

--- a/src/components/LeaderboardRow.tsx
+++ b/src/components/LeaderboardRow.tsx
@@ -67,7 +67,7 @@ export const LeaderboardRowHtml = ({
         </div>
       </td>
       <td class="px-1 py-4 md:px-3 lg:px-6">
-        <span>{ratingSystem.toNumber(rating)}</span>
+        <span>{ratingSystem.toString(rating)}</span>
         <DiffIcon
           before={
             ratingBefore !== undefined

--- a/src/components/LeaderboardTable.tsx
+++ b/src/components/LeaderboardTable.tsx
@@ -1,16 +1,18 @@
 import { type RESULT } from "../lib/matchStatistics";
+import { type Rating, type RatingSystem } from "../lib/ratings/rating";
 import { LeaderboardRowHtml } from "./LeaderboardRow";
 
 export const LeaderboardTableHtml = ({
   rows,
+  ratingSystem,
   isCurrentSeason,
 }: {
   rows: {
     userId: string;
     rank: number;
     name: string;
-    rating: number;
-    ratingBefore?: number;
+    rating: Rating;
+    ratingBefore?: Rating;
     rankBefore?: number;
     lastPlayed: Date;
     latestPlayerResults: {
@@ -19,6 +21,7 @@ export const LeaderboardTableHtml = ({
       results: RESULT[];
     };
   }[];
+  ratingSystem: RatingSystem<Rating>;
   isCurrentSeason: boolean;
 }) => (
   <>
@@ -42,6 +45,7 @@ export const LeaderboardTableHtml = ({
             {rows.map((row) => (
               <LeaderboardRowHtml
                 {...row}
+                ratingSystem={ratingSystem}
                 isCurrentSeason={isCurrentSeason}
                 isLowestRanked={row.rank === rows.length}
               />

--- a/src/db/schema/season.ts
+++ b/src/db/schema/season.ts
@@ -24,7 +24,7 @@ export const ratingSystemTypes = [
   "underdog",
   "gameCount",
   "uniqueOpponentsBeaten",
-  "moodRing",
+  "kitchenThermometer",
 ] as const;
 
 export const seasonsTbl = sqliteTable(

--- a/src/db/schema/season.ts
+++ b/src/db/schema/season.ts
@@ -24,6 +24,7 @@ export const ratingSystemTypes = [
   "underdog",
   "gameCount",
   "uniqueOpponentsBeaten",
+  "moodRing",
 ] as const;
 
 export const seasonsTbl = sqliteTable(

--- a/src/lib/ratings/eloRatingSystem.ts
+++ b/src/lib/ratings/eloRatingSystem.ts
@@ -132,6 +132,10 @@ export function elo(config?: EloConfig): RatingSystem<EloRating> {
       return Math.floor(score);
     },
 
+    toString(score: EloRating) {
+      return this.toNumber(score).toString();
+    },
+
     equals(a: EloRating | undefined, b: EloRating | undefined) {
       return a === b;
     },

--- a/src/lib/ratings/gameCountRatingSystem.ts
+++ b/src/lib/ratings/gameCountRatingSystem.ts
@@ -31,6 +31,10 @@ export function gameCount(): RatingSystem<GameCountRating> {
       return rating;
     },
 
+    toString(rating: GameCountRating) {
+      return this.toNumber(rating).toString();
+    },
+
     equals(a: GameCountRating | undefined, b: GameCountRating | undefined) {
       return a === b;
     },

--- a/src/lib/ratings/kitchenThermometerRatingSystem.ts
+++ b/src/lib/ratings/kitchenThermometerRatingSystem.ts
@@ -5,9 +5,9 @@ import {
   type RatingSystem,
 } from "./rating";
 
-export type MoodRingRating = number;
+export type KitchenThermometerRating = number;
 
-export interface MoodRingConfig {
+export interface KitchenThermometerConfig {
   winHeat: number;
   blowoutThreshold: number;
   blowoutBonus: number;
@@ -16,11 +16,11 @@ export interface MoodRingConfig {
   minHeat: number;
 }
 
-export function moodRing(
-  config?: MoodRingConfig,
-): RatingSystem<MoodRingRating> {
+export function kitchenThermometer(
+  config?: KitchenThermometerConfig,
+): RatingSystem<KitchenThermometerRating> {
   /*
-    A momentum-based rating system inspired by mood rings.
+    A momentum-based rating system inspired by a kitchen thermometer.
 
     Each player carries "heat" that rises with wins and falls with losses.
 
@@ -28,7 +28,7 @@ export function moodRing(
     score difference does not matter.
   */
 
-  const selectedConfig: MoodRingConfig = config ?? {
+  const selectedConfig: KitchenThermometerConfig = config ?? {
     winHeat: 15,
     blowoutThreshold: 100,
     blowoutBonus: 10,
@@ -38,10 +38,10 @@ export function moodRing(
   };
 
   function applyHeatChange(
-    currentHeat: MoodRingRating,
+    currentHeat: KitchenThermometerRating,
     outcome: "win" | "loss" | "draw",
     scoreDiff: number,
-  ): MoodRingRating {
+  ): KitchenThermometerRating {
     const {
       winHeat,
       blowoutThreshold,
@@ -67,10 +67,10 @@ export function moodRing(
   }
 
   function ratePlayer(
-    player: PlayerWithRating<MoodRingRating>,
+    player: PlayerWithRating<KitchenThermometerRating>,
     outcome: "win" | "loss" | "draw",
     scoreDiff: number,
-  ): PlayerWithRating<MoodRingRating> {
+  ): PlayerWithRating<KitchenThermometerRating> {
     return {
       player: player.player,
       rating: applyHeatChange(player.rating, outcome, scoreDiff),
@@ -78,12 +78,12 @@ export function moodRing(
   }
 
   return {
-    type: "moodRing",
+    type: "kitchenThermometer",
     defaultRating: 0,
 
     rateMatch(
-      match: MatchWithRatings<MoodRingRating>,
-    ): PlayerWithRating<MoodRingRating>[] {
+      match: MatchWithRatings<KitchenThermometerRating>,
+    ): PlayerWithRating<KitchenThermometerRating>[] {
       const whiteTeam = [match.whitePlayerOne, match.whitePlayerTwo].filter(
         isDefined,
       );
@@ -110,11 +110,11 @@ export function moodRing(
       ];
     },
 
-    toNumber(rating: MoodRingRating) {
+    toNumber(rating: KitchenThermometerRating) {
       return rating;
     },
 
-    toString(heat: MoodRingRating) {
+    toString(heat: KitchenThermometerRating) {
       if (heat >= 220) return "Roasted";
       if (heat >= 180) return "Flash Fried";
       if (heat >= 140) return "Broiling";
@@ -127,7 +127,10 @@ export function moodRing(
       return "Deep Freeze";
     },
 
-    equals(a: MoodRingRating | undefined, b: MoodRingRating | undefined) {
+    equals(
+      a: KitchenThermometerRating | undefined,
+      b: KitchenThermometerRating | undefined,
+    ) {
       return a === b;
     },
   };

--- a/src/lib/ratings/kitchenThermometerRatingSystem.ts
+++ b/src/lib/ratings/kitchenThermometerRatingSystem.ts
@@ -29,11 +29,11 @@ export function kitchenThermometer(
   */
 
   const selectedConfig: KitchenThermometerConfig = config ?? {
-    winHeat: 15,
+    winHeat: 30,
     blowoutThreshold: 100,
-    blowoutBonus: 10,
+    blowoutBonus: 30,
     decayRate: 0.1,
-    lossDecayRate: 0.3,
+    lossDecayRate: 0.2,
     minHeat: 0,
   };
 
@@ -115,15 +115,15 @@ export function kitchenThermometer(
     },
 
     toString(heat: KitchenThermometerRating) {
-      if (heat >= 220) return "Roasted";
-      if (heat >= 180) return "Flash Fried";
+      if (heat >= 200) return "Roasted";
+      if (heat >= 175) return "Flash Fried";
       if (heat >= 140) return "Broiling";
-      if (heat >= 100) return "Boiling Point";
-      if (heat >= 75) return "Sizzling";
-      if (heat >= 50) return "Simmering";
-      if (heat >= 30) return "Lukewarm";
-      if (heat >= 15) return "Room Temp";
-      if (heat >= 5) return "Chilled";
+      if (heat >= 110) return "Boiling Point";
+      if (heat >= 90) return "Sizzling";
+      if (heat >= 75) return "Simmering";
+      if (heat >= 45) return "Lukewarm";
+      if (heat >= 20) return "Room Temp";
+      if (heat >= 15) return "Chilled";
       return "Deep Freeze";
     },
 

--- a/src/lib/ratings/moodRingRatingSystem.ts
+++ b/src/lib/ratings/moodRingRatingSystem.ts
@@ -7,8 +7,6 @@ import {
 
 export type MoodRingRating = number;
 
-export type Mood = "cold" | "mid" | "onFire" | "cooking";
-
 export interface MoodRingConfig {
   winHeat: number;
   lossHeat: number;
@@ -16,26 +14,6 @@ export interface MoodRingConfig {
   blowoutBonus: number;
   decayRate: number;
   minHeat: number;
-}
-
-export function getMoodFromHeat(heat: MoodRingRating): Mood {
-  if (heat >= 80) return "cooking";
-  if (heat >= 50) return "onFire";
-  if (heat >= 20) return "mid";
-  return "cold";
-}
-
-export function prettyMood(mood: Mood): string {
-  switch (mood) {
-    case "cold":
-      return "Cold";
-    case "mid":
-      return "Mid";
-    case "onFire":
-      return "On Fire";
-    case "cooking":
-      return "Cooking";
-  }
 }
 
 export function moodRing(
@@ -133,6 +111,13 @@ export function moodRing(
 
     toNumber(rating: MoodRingRating) {
       return rating;
+    },
+
+    toString(heat: MoodRingRating) {
+      if (heat >= 80) return "Cooking";
+      if (heat >= 50) return "On Fire";
+      if (heat >= 20) return "Mid";
+      return "Cold";
     },
 
     equals(a: MoodRingRating | undefined, b: MoodRingRating | undefined) {

--- a/src/lib/ratings/moodRingRatingSystem.ts
+++ b/src/lib/ratings/moodRingRatingSystem.ts
@@ -9,10 +9,10 @@ export type MoodRingRating = number;
 
 export interface MoodRingConfig {
   winHeat: number;
-  lossHeat: number;
   blowoutThreshold: number;
   blowoutBonus: number;
   decayRate: number;
+  lossDecayRate: number;
   minHeat: number;
 }
 
@@ -30,10 +30,10 @@ export function moodRing(
 
   const selectedConfig: MoodRingConfig = config ?? {
     winHeat: 10,
-    lossHeat: 8,
     blowoutThreshold: 100,
     blowoutBonus: 5,
-    decayRate: 0.9,
+    decayRate: 0.1,
+    lossDecayRate: 0.3,
     minHeat: 0,
   };
 
@@ -44,22 +44,23 @@ export function moodRing(
   ): MoodRingRating {
     const {
       winHeat,
-      lossHeat,
       blowoutThreshold,
       blowoutBonus,
       decayRate,
+      lossDecayRate,
       minHeat,
     } = selectedConfig;
 
-    let heat = currentHeat * decayRate;
+    let heat = currentHeat;
+
+    const percentLoss = outcome === "loss" ? lossDecayRate : decayRate;
+    heat *= 1 - percentLoss;
 
     if (outcome === "win") {
       heat += winHeat;
       if (scoreDiff > blowoutThreshold) {
         heat += blowoutBonus;
       }
-    } else if (outcome === "loss") {
-      heat -= lossHeat;
     }
 
     return Math.max(minHeat, Math.round(heat));

--- a/src/lib/ratings/moodRingRatingSystem.ts
+++ b/src/lib/ratings/moodRingRatingSystem.ts
@@ -1,0 +1,142 @@
+import { isDefined } from "../utils";
+import {
+  type MatchWithRatings,
+  type PlayerWithRating,
+  type RatingSystem,
+} from "./rating";
+
+export type MoodRingRating = number;
+
+export type Mood = "cold" | "mid" | "onFire" | "cooking";
+
+export interface MoodRingConfig {
+  winHeat: number;
+  lossHeat: number;
+  blowoutThreshold: number;
+  blowoutBonus: number;
+  decayRate: number;
+  minHeat: number;
+}
+
+export function getMoodFromHeat(heat: MoodRingRating): Mood {
+  if (heat >= 80) return "cooking";
+  if (heat >= 50) return "onFire";
+  if (heat >= 20) return "mid";
+  return "cold";
+}
+
+export function prettyMood(mood: Mood): string {
+  switch (mood) {
+    case "cold":
+      return "Cold";
+    case "mid":
+      return "Mid";
+    case "onFire":
+      return "On Fire";
+    case "cooking":
+      return "Cooking";
+  }
+}
+
+export function moodRing(
+  config?: MoodRingConfig,
+): RatingSystem<MoodRingRating> {
+  /*
+    A momentum-based rating system inspired by mood rings.
+
+    Each player carries "heat" that rises with wins and falls with losses.
+
+    Wins by more than 100 points add a small blowout bonus; otherwise
+    score difference does not matter.
+  */
+
+  const selectedConfig: MoodRingConfig = config ?? {
+    winHeat: 10,
+    lossHeat: 8,
+    blowoutThreshold: 100,
+    blowoutBonus: 5,
+    decayRate: 0.9,
+    minHeat: 0,
+  };
+
+  function applyHeatChange(
+    currentHeat: MoodRingRating,
+    outcome: "win" | "loss" | "draw",
+    scoreDiff: number,
+  ): MoodRingRating {
+    const {
+      winHeat,
+      lossHeat,
+      blowoutThreshold,
+      blowoutBonus,
+      decayRate,
+      minHeat,
+    } = selectedConfig;
+
+    let heat = currentHeat * decayRate;
+
+    if (outcome === "win") {
+      heat += winHeat;
+      if (scoreDiff > blowoutThreshold) {
+        heat += blowoutBonus;
+      }
+    } else if (outcome === "loss") {
+      heat -= lossHeat;
+    }
+
+    return Math.max(minHeat, Math.round(heat));
+  }
+
+  function ratePlayer(
+    player: PlayerWithRating<MoodRingRating>,
+    outcome: "win" | "loss" | "draw",
+    scoreDiff: number,
+  ): PlayerWithRating<MoodRingRating> {
+    return {
+      player: player.player,
+      rating: applyHeatChange(player.rating, outcome, scoreDiff),
+    };
+  }
+
+  return {
+    type: "moodRing",
+    defaultRating: 0,
+
+    rateMatch(
+      match: MatchWithRatings<MoodRingRating>,
+    ): PlayerWithRating<MoodRingRating>[] {
+      const whiteTeam = [match.whitePlayerOne, match.whitePlayerTwo].filter(
+        isDefined,
+      );
+      const blackTeam = [match.blackPlayerOne, match.blackPlayerTwo].filter(
+        isDefined,
+      );
+
+      if (match.result === "Draw") {
+        return [...whiteTeam, ...blackTeam].map((player) =>
+          ratePlayer(player, "draw", match.scoreDiff),
+        );
+      }
+
+      const winningTeam = match.result === "White" ? whiteTeam : blackTeam;
+      const losingTeam = match.result === "White" ? blackTeam : whiteTeam;
+
+      return [
+        ...winningTeam.map((player) =>
+          ratePlayer(player, "win", match.scoreDiff),
+        ),
+        ...losingTeam.map((player) =>
+          ratePlayer(player, "loss", match.scoreDiff),
+        ),
+      ];
+    },
+
+    toNumber(rating: MoodRingRating) {
+      return rating;
+    },
+
+    equals(a: MoodRingRating | undefined, b: MoodRingRating | undefined) {
+      return a === b;
+    },
+  };
+}

--- a/src/lib/ratings/moodRingRatingSystem.ts
+++ b/src/lib/ratings/moodRingRatingSystem.ts
@@ -29,9 +29,9 @@ export function moodRing(
   */
 
   const selectedConfig: MoodRingConfig = config ?? {
-    winHeat: 10,
+    winHeat: 15,
     blowoutThreshold: 100,
-    blowoutBonus: 5,
+    blowoutBonus: 10,
     decayRate: 0.1,
     lossDecayRate: 0.3,
     minHeat: 0,
@@ -115,10 +115,16 @@ export function moodRing(
     },
 
     toString(heat: MoodRingRating) {
-      if (heat >= 80) return "Cooking";
-      if (heat >= 50) return "On Fire";
-      if (heat >= 20) return "Mid";
-      return "Cold";
+      if (heat >= 220) return "Roasted";
+      if (heat >= 180) return "Flash Fried";
+      if (heat >= 140) return "Broiling";
+      if (heat >= 100) return "Boiling Point";
+      if (heat >= 75) return "Sizzling";
+      if (heat >= 50) return "Simmering";
+      if (heat >= 30) return "Lukewarm";
+      if (heat >= 15) return "Room Temp";
+      if (heat >= 5) return "Chilled";
+      return "Deep Freeze";
     },
 
     equals(a: MoodRingRating | undefined, b: MoodRingRating | undefined) {

--- a/src/lib/ratings/openskillRatingSystem.ts
+++ b/src/lib/ratings/openskillRatingSystem.ts
@@ -82,6 +82,10 @@ export function openskill(options?: Options): RatingSystem<OpenskillRating> {
       return Math.floor(ordinal(rating, selectedOptions));
     },
 
+    toString(rating: OpenskillRating) {
+      return this.toNumber(rating).toString();
+    },
+
     equals(a: OpenskillRating | undefined, b: OpenskillRating | undefined) {
       if (a === undefined && b === undefined) return true;
       if (a === undefined || b === undefined) return false;

--- a/src/lib/ratings/rating.ts
+++ b/src/lib/ratings/rating.ts
@@ -3,7 +3,10 @@ import { getDatePartFromDate, subtractDays } from "../dateUtils";
 import { isDefined } from "../utils";
 import { elo, type EloRating } from "./eloRatingSystem";
 import { gameCount, type GameCountRating } from "./gameCountRatingSystem";
-import { moodRing, type MoodRingRating } from "./moodRingRatingSystem";
+import {
+  kitchenThermometer,
+  type KitchenThermometerRating,
+} from "./kitchenThermometerRatingSystem";
 import { openskill, type OpenskillRating } from "./openskillRatingSystem";
 import { scoreAvg, type ScoreAvgRating } from "./scoreAvgRatingSystem";
 import { scoreDiff, type ScoreDiffRating } from "./scoreDiffRatingSystem";
@@ -29,7 +32,7 @@ export type Rating =
   | UnderdogRating
   | GameCountRating
   | UniqueOpponentsBeatenRating
-  | MoodRingRating;
+  | KitchenThermometerRating;
 /* eslint-enable @typescript-eslint/no-duplicate-type-constituents */
 
 export interface RatingSystem<TRating> {
@@ -252,8 +255,8 @@ export function getRatingSystem(type: RatingSystemType): RatingSystem<Rating> {
       return uniqueOpponentsBeaten() as RatingSystem<Rating>;
     case "elo":
       return elo() as RatingSystem<Rating>;
-    case "moodRing":
-      return moodRing() as RatingSystem<Rating>;
+    case "kitchenThermometer":
+      return kitchenThermometer() as RatingSystem<Rating>;
   }
 }
 
@@ -277,8 +280,8 @@ export function prettyRatingSystemType(ratingSystem: RatingSystemType): string {
       return "Game Count";
     case "uniqueOpponentsBeaten":
       return "Unique Opponents Beaten";
-    case "moodRing":
-      return "Mood Ring";
+    case "kitchenThermometer":
+      return "Kitchen Thermometer";
   }
 }
 

--- a/src/lib/ratings/rating.ts
+++ b/src/lib/ratings/rating.ts
@@ -3,6 +3,7 @@ import { getDatePartFromDate, subtractDays } from "../dateUtils";
 import { isDefined } from "../utils";
 import { elo, type EloRating } from "./eloRatingSystem";
 import { gameCount, type GameCountRating } from "./gameCountRatingSystem";
+import { moodRing, type MoodRingRating } from "./moodRingRatingSystem";
 import { openskill, type OpenskillRating } from "./openskillRatingSystem";
 import { scoreAvg, type ScoreAvgRating } from "./scoreAvgRatingSystem";
 import { scoreDiff, type ScoreDiffRating } from "./scoreDiffRatingSystem";
@@ -27,7 +28,8 @@ export type Rating =
   | StreakMultiplierRating
   | UnderdogRating
   | GameCountRating
-  | UniqueOpponentsBeatenRating;
+  | UniqueOpponentsBeatenRating
+  | MoodRingRating;
 /* eslint-enable @typescript-eslint/no-duplicate-type-constituents */
 
 export interface RatingSystem<TRating> {
@@ -249,6 +251,8 @@ export function getRatingSystem(type: RatingSystemType): RatingSystem<Rating> {
       return uniqueOpponentsBeaten() as RatingSystem<Rating>;
     case "elo":
       return elo() as RatingSystem<Rating>;
+    case "moodRing":
+      return moodRing() as RatingSystem<Rating>;
   }
 }
 
@@ -272,6 +276,8 @@ export function prettyRatingSystemType(ratingSystem: RatingSystemType): string {
       return "Game Count";
     case "uniqueOpponentsBeaten":
       return "Unique Opponents Beaten";
+    case "moodRing":
+      return "Mood Ring";
   }
 }
 

--- a/src/lib/ratings/rating.ts
+++ b/src/lib/ratings/rating.ts
@@ -37,6 +37,7 @@ export interface RatingSystem<TRating> {
   defaultRating: TRating;
   rateMatch: (match: MatchWithRatings<TRating>) => PlayerWithRating<TRating>[];
   toNumber: (rating: TRating) => number;
+  toString: (rating: TRating) => string;
   equals: (a: TRating | undefined, b: TRating | undefined) => boolean;
 }
 

--- a/src/lib/ratings/scoreAvgRatingSystem.ts
+++ b/src/lib/ratings/scoreAvgRatingSystem.ts
@@ -61,6 +61,10 @@ export function scoreAvg(): RatingSystem<ScoreAvgRating> {
       return rating.count === 0 ? 0 : Math.floor(rating.diff / rating.count);
     },
 
+    toString(rating: ScoreAvgRating) {
+      return this.toNumber(rating).toString();
+    },
+
     equals(a: ScoreAvgRating | undefined, b: ScoreAvgRating | undefined) {
       if (a === undefined && b === undefined) return true;
       if (a === undefined || b === undefined) return false;

--- a/src/lib/ratings/scoreDiffRatingSystem.ts
+++ b/src/lib/ratings/scoreDiffRatingSystem.ts
@@ -56,6 +56,10 @@ export function scoreDiff(): RatingSystem<ScoreDiffRating> {
       return rating;
     },
 
+    toString(rating: ScoreDiffRating) {
+      return this.toNumber(rating).toString();
+    },
+
     equals(a: ScoreDiffRating | undefined, b: ScoreDiffRating | undefined) {
       return a === b;
     },

--- a/src/lib/ratings/streakMultiplierRatingSystem.ts
+++ b/src/lib/ratings/streakMultiplierRatingSystem.ts
@@ -107,6 +107,10 @@ export function streakMultiplier(
       return rating.points;
     },
 
+    toString(rating: StreakMultiplierRating) {
+      return this.toNumber(rating).toString();
+    },
+
     equals(
       a: StreakMultiplierRating | undefined,
       b: StreakMultiplierRating | undefined,

--- a/src/lib/ratings/underdogRatingSystem.ts
+++ b/src/lib/ratings/underdogRatingSystem.ts
@@ -162,6 +162,10 @@ export function underdog(
       return rating;
     },
 
+    toString(rating: UnderdogRating) {
+      return this.toNumber(rating).toString();
+    },
+
     equals(a: UnderdogRating | undefined, b: UnderdogRating | undefined) {
       return a === b;
     },

--- a/src/lib/ratings/uniqueOpponentsBeaten.ts
+++ b/src/lib/ratings/uniqueOpponentsBeaten.ts
@@ -48,6 +48,10 @@ export function uniqueOpponentsBeaten(): RatingSystem<UniqueOpponentsBeatenRatin
       return rating.length;
     },
 
+    toString(rating: UniqueOpponentsBeatenRating) {
+      return this.toNumber(rating).toString();
+    },
+
     equals(
       a: UniqueOpponentsBeatenRating | undefined,
       b: UniqueOpponentsBeatenRating | undefined,

--- a/src/lib/ratings/xpRatingSystem.ts
+++ b/src/lib/ratings/xpRatingSystem.ts
@@ -105,6 +105,10 @@ export function xp(config?: XPConfig): RatingSystem<XPRating> {
       return calculateLevel(xp);
     },
 
+    toString(xp: XPRating) {
+      return this.toNumber(xp).toString();
+    },
+
     equals(a: XPRating | undefined, b: XPRating | undefined) {
       return a === b;
     },

--- a/src/pages/leaderboard.tsx
+++ b/src/pages/leaderboard.tsx
@@ -70,10 +70,8 @@ const playerQuery = async (
       rankBefore:
         changes?.rankBefore !== undefined ? changes.rankBefore + 1 : undefined,
       name: player.player.name,
-      rating: ratingSystem.toNumber(player.rating),
-      ratingBefore: changes?.ratingBefore
-        ? ratingSystem.toNumber(changes.ratingBefore)
-        : undefined,
+      rating: player.rating,
+      ratingBefore: changes?.ratingBefore,
       lastPlayed:
         lastPlayed.find((match) => match.player.id === player.player.id)
           ?.lastPlayed ?? new Date(0),
@@ -144,6 +142,7 @@ async function LeaderboardTable(
       </div>
       <LeaderboardTableHtml
         rows={rows}
+        ratingSystem={ratingSystem}
         isCurrentSeason={isCurrentSeason(season.id, seasons)}
       />
     </>

--- a/src/pages/result.tsx
+++ b/src/pages/result.tsx
@@ -1,6 +1,7 @@
 import { type PropsWithChildren } from "@kitajs/html";
 import Elysia from "elysia";
 import { type Session } from "lucia";
+import { DiffIcon } from "../components/DiffIcon";
 import { HeaderHtml } from "../components/header";
 import { HxButton } from "../components/HxButton";
 import { LayoutHtml } from "../components/Layout";
@@ -119,10 +120,8 @@ async function RatingDiff({
     .map((x) => ({
       playerId: x.player.id,
       playerName: x.player.name,
-      ratingBefore: isDefined(x.ratingBefore)
-        ? ratingSystem.toNumber(x.ratingBefore)
-        : undefined,
-      ratingAfter: ratingSystem.toNumber(x.ratingAfter),
+      ratingAfter: x.ratingAfter,
+      ratingBefore: x.ratingBefore,
       rankBefore: x.rankBefore,
       rankAfter: x.rankAfter,
     }))
@@ -131,7 +130,7 @@ async function RatingDiff({
   return (
     <RatingDiffTable>
       {matchDiff.map((playerDiff) => (
-        <RatingDiffTableRow {...playerDiff} />
+        <RatingDiffTableRow {...playerDiff} ratingSystem={ratingSystem} />
       ))}
     </RatingDiffTable>
   );
@@ -167,15 +166,17 @@ function RatingDiffTable({ children }: PropsWithChildren): JSX.Element {
 function RatingDiffTableRow({
   playerId,
   playerName,
-  ratingBefore,
   ratingAfter,
+  ratingBefore,
+  ratingSystem,
   rankBefore,
   rankAfter,
 }: {
   playerId: string;
   playerName: string;
-  ratingBefore: number | undefined;
-  ratingAfter: number;
+  ratingAfter: Rating;
+  ratingBefore: Rating | undefined;
+  ratingSystem: RatingSystem<Rating>;
   rankBefore: number | undefined;
   rankAfter: number;
 }): JSX.Element {
@@ -214,43 +215,18 @@ function RatingDiffTableRow({
           </div>
         </th>
         <td class="px-1 py-4 md:px-3 lg:px-6">
-          <span class="inline-block	w-8">{ratingAfter}</span>
+          <span class="inline-block">{ratingSystem.toString(ratingAfter)}</span>
           <DiffIcon
-            before={ratingBefore}
-            after={ratingAfter}
+            before={
+              isDefined(ratingBefore)
+                ? ratingSystem.toNumber(ratingBefore)
+                : undefined
+            }
+            after={ratingSystem.toNumber(ratingAfter)}
             isHigherBetter={true}
           />
         </td>
       </tr>
     </>
-  );
-}
-
-function DiffIcon({
-  before,
-  after,
-  isHigherBetter,
-}: {
-  before: number | undefined;
-  after: number;
-  isHigherBetter: boolean;
-}): JSX.Element {
-  const areDefined = isDefined(before) && isDefined(after);
-  const areEqual = before === after;
-  const shouldDisplay = areDefined && !areEqual;
-
-  if (!shouldDisplay) {
-    return <></>;
-  }
-
-  const difference = after - before;
-  const isPositive = difference > 0;
-  const isImproved = isHigherBetter ? isPositive : !isPositive;
-
-  return (
-    <span class={["pl-1", isImproved ? "text-green-500" : "text-red-500"]}>
-      {isImproved ? "▲" : "▼"}
-      {Math.abs(difference)}
-    </span>
   );
 }


### PR DESCRIPTION
Det er 100% vibet, men synes algoritmen er sjov nok.
Jeg har ikke reviewet det selv endnu, kan vi gøre under turneringen 😉 
Jeg har lige hurtigt kørt det, men ikke testet særligt meget



# how works
  **Mood Ring** tracks each player's **heat** — a momentum score that reflects recent form, not lifetime skill.
  Every match, heat is updated in three steps:
  1. **Decay** — heat is multiplied by 0.9, so it fades over time even if you keep playing.
  2. **Result** — wins add +10, losses subtract −8, draws change nothing beyond decay.
  3. **Blowout bonus** — wins by more than 100 points add an extra +5; otherwise score difference is ignored.

Heat is floored at 0 and used for both ranking and display. The leaderboard shows a mood label instead of the raw number:

| Heat | Mood     |
|------|----------|
| 0–19 | Cold     |
| 20–49 | Mid      |
| 50–79 | On Fire  |
| 80+  | Cooking  |

So the system rewards win streaks and punishes losing runs, with a small nod to dominant victories — but a few bad losses or time away will cool you off quickly.